### PR TITLE
added terms.html to _default dir to suppress error Found no layout fo…

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,7 +1,10 @@
 baseURL = "https://example.com/"
 languageCode = "en-us"
 title = "Athena Hugo Theme"
-theme = "../.."
+theme = "athena-hugo-theme"
+themesDir = "../.."
+
+#disableKinds = "taxonomyTerm"
 
 [params]
 description = "A clean and readable Hugo theme (port of https://github.com/broccolini/athena)"
@@ -9,3 +12,5 @@ dateform = "Jan 2, 2006"
 disable_next_prev = true
 github_repo = "mnoronha.com"
 github_username = "mtn"
+
+


### PR DESCRIPTION
…r taxonomy term

You have 2 options. Either merge this pull request or go ahead and try to fix the error `Found no layout for taxonomyTerm` 

See https://github.com/vjeantet/hugo-theme-docdock/issues/169 

Contrary to https://github.com/gohugoio/hugo/issues/3386#issuecomment-302493626 this issue with your theme is reproducible in all shapes and forms and with different hugo versions.

Adding **terms.html** to **_default** suppresses the error and thus allowing your theme from being generated from the **Themes** hugo site in the future. 

You can also add `disableKinds = "taxonomyTerm"` on the config file as well.