### PR TITLE
fix: duplicate list element

### DIFF
--- a/layouts/section/list.html
+++ b/layouts/section/list.html
@@ -20,13 +20,6 @@
 
         </div>
       </header>
-
-      <div class="container mx-auto px-2 py-2">
-        {{ range sort .Data.Pages "Date" "desc" }}
-          {{ partial "post_block.html" . }}
-        {{ end }}
-      </div>
-
     </div>
 
 


### PR DESCRIPTION
There's a duplicate of the div for the list of posts. You can see it in the demo site. This removes one of them.